### PR TITLE
knxprod without translations not loadable

### DIFF
--- a/Kaenx.Creator/Classes/ImportHelper.cs
+++ b/Kaenx.Creator/Classes/ImportHelper.cs
@@ -457,6 +457,10 @@ namespace Kaenx.Creator.Classes
             _translations.Clear();
             if(xlangs == null) return;
             
+            if(xlang.Elements().Count() == 0)
+            {
+                break;
+            }
             foreach(XElement xlang in xlangs.Elements()) {
                 string cultureCode = xlang.Attribute("Identifier").Value;
 


### PR DESCRIPTION
Added protection to be able to load knxprods without translations: for example:

<Languages>
 <Language Identifier="de-DE">
  <TranslationUnit RefId="M-013A_A-0005-64-8861">
  </TranslationUnit>
</Languages>